### PR TITLE
Add the initial migration.

### DIFF
--- a/notification/migrations/0001_initial.py
+++ b/notification/migrations/0001_initial.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='NoticeQueueBatch',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('pickled_data', models.TextField()),
+            ],
+        ),
+        migrations.CreateModel(
+            name='NoticeSetting',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('medium', models.CharField(max_length=1, verbose_name='medium', choices=[(0, b'email')])),
+                ('send', models.BooleanField(verbose_name='send')),
+            ],
+            options={
+                'verbose_name': 'notice setting',
+                'verbose_name_plural': 'notice settings',
+            },
+        ),
+        migrations.CreateModel(
+            name='NoticeType',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('label', models.CharField(max_length=40, verbose_name='label')),
+                ('display', models.CharField(max_length=50, verbose_name='display')),
+                ('description', models.CharField(max_length=100, verbose_name='description')),
+                ('default', models.IntegerField(verbose_name='default')),
+            ],
+            options={
+                'verbose_name': 'notice type',
+                'verbose_name_plural': 'notice types',
+            },
+        ),
+        migrations.AddField(
+            model_name='noticesetting',
+            name='notice_type',
+            field=models.ForeignKey(verbose_name='notice type', to='notification.NoticeType'),
+        ),
+        migrations.AddField(
+            model_name='noticesetting',
+            name='user',
+            field=models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterUniqueTogether(
+            name='noticesetting',
+            unique_together=set([('user', 'notice_type', 'medium')]),
+        ),
+    ]


### PR DESCRIPTION
This pull request will allow this branch to work with newer versions of Django that require migrations out of the box, so that the migrations won't have to be generated manually by whoever is using the notification app.
